### PR TITLE
Fixing a problem with escaped characters in URLs.

### DIFF
--- a/AsyncOAuth/Internal/Utility.cs
+++ b/AsyncOAuth/Internal/Utility.cs
@@ -1,9 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
-using System.Net;
-using System.Text;
 
 namespace AsyncOAuth
 {
@@ -45,7 +42,8 @@ namespace AsyncOAuth
                .Select(x =>
                {
                    var xs = x.Split('=');
-                   return new KeyValuePair<string, string>(xs[0], xs[1]);
+                   var unescapedValue = Uri.UnescapeDataString(xs[1]);
+                   return new KeyValuePair<string, string>(xs[0], unescapedValue);
                });
 
             return queryParams;

--- a/AsyncOAuth/OAuthUtility.cs
+++ b/AsyncOAuth/OAuthUtility.cs
@@ -42,7 +42,7 @@ namespace AsyncOAuth
 
             var hmacKeyBase = consumerSecret.UrlEncode() + "&" + ((token == null) ? "" : token.Secret).UrlEncode();
 
-            var queryParams = Utility.ParseQueryString(uri.GetComponents(UriComponents.Query | UriComponents.KeepDelimiter, UriFormat.Unescaped));
+            var queryParams = Utility.ParseQueryString(uri.GetComponents(UriComponents.Query | UriComponents.KeepDelimiter, UriFormat.UriEscaped));
 
             var stringParameter = parameters
                 .Where(x => x.Key.ToLower() != "realm")


### PR DESCRIPTION
If the escaped characters were something special, like '&' or '=', it would cause problems when splitting parameters.
The solution I've found is to keep the query string escaped, then unescape the value on ParseQueryString.
