### PR TITLE
Fixing a problem with posting text.

### DIFF
--- a/AsyncOAuth/Internal/Utility.cs
+++ b/AsyncOAuth/Internal/Utility.cs
@@ -23,11 +23,9 @@ namespace AsyncOAuth
                 .Replace(")", "%29");
         }
 
-
         public static string UrlDecode(this string stringToUnescape)
         {
-            stringToUnescape = stringToUnescape.Replace("+", " ");
-            return Uri.UnescapeDataString(stringToUnescape)
+            return UrlDecodeForPost(stringToUnescape)
                 .Replace("%21", "!")
                 .Replace("%2A", "*")
                 .Replace("%27", "'")
@@ -35,14 +33,28 @@ namespace AsyncOAuth
                 .Replace("%29", ")");
         }
 
-        public static IEnumerable<KeyValuePair<string, string>> ParseQueryString(string query)
+        public static string UrlDecodeForPost(this string stringToUnescape)
+        {
+            stringToUnescape = stringToUnescape.Replace("+", " ");
+            return Uri.UnescapeDataString(stringToUnescape);
+        }
+
+
+        public static IEnumerable<KeyValuePair<string, string>> ParseQueryString(string query, bool post = false)
         {
             var queryParams = query.TrimStart('?').Split('&')
                .Where(x => x != "")
                .Select(x =>
                {
                    var xs = x.Split('=');
-                   return new KeyValuePair<string, string>(xs[0].UrlDecode(), xs[1].UrlDecode());
+                   if (post)
+                   {
+                       return new KeyValuePair<string, string>(xs[0].UrlDecode(), xs[1].UrlDecodeForPost());
+                   }
+                   else
+                   {
+                       return new KeyValuePair<string, string>(xs[0].UrlDecode(), xs[1].UrlDecode());
+                   }
                });
 
             return queryParams;

--- a/AsyncOAuth/OAuthMessageHandler.cs
+++ b/AsyncOAuth/OAuthMessageHandler.cs
@@ -38,7 +38,7 @@ namespace AsyncOAuth
                 {
                     // url encoded string
                     var extraParameter = await request.Content.ReadAsStringAsync().ConfigureAwait(false);
-                    var parsed = Utility.ParseQueryString(extraParameter); // url decoded
+                    var parsed = Utility.ParseQueryString(extraParameter, true); // url decoded
                     sendParameter = sendParameter.Concat(parsed);
                 }
             }


### PR DESCRIPTION
Element "%21", "%2A", "%27", "%28" and "%29" are unescaped by mistake when sending messages by POST with OAuth.
I found this problem during posting text to twitter: https://github.com/karno/StarryEyes/issues/70
