### PR TITLE
Fixed OAuthToken in header, needs to be url encoded

### DIFF
--- a/AsyncOAuth.ConsoleApp/AsyncOAuth.ConsoleApp.csproj
+++ b/AsyncOAuth.ConsoleApp/AsyncOAuth.ConsoleApp.csproj
@@ -59,6 +59,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="ETrade.cs" />
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Twitter.cs" />

--- a/AsyncOAuth.ConsoleApp/ETrade.cs
+++ b/AsyncOAuth.ConsoleApp/ETrade.cs
@@ -1,0 +1,93 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Net.Http;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace AsyncOAuth.ConsoleApp
+{
+    // a sample of ETrade client
+    public class ETradeClient
+    {
+        readonly string consumerKey;
+        readonly string consumerSecret;
+        readonly AccessToken accessToken;
+
+        public ETradeClient(string consumerKey, string consumerSecret, AccessToken accessToken)
+        {
+            this.consumerKey = consumerKey;
+            this.consumerSecret = consumerSecret;
+            this.accessToken = accessToken;
+        }
+
+        // sample flow for ETrade authroize
+        public async static Task<AccessToken> AuthorizeSample(string consumerKey, string consumerSecret)
+        {
+            try
+            {
+                // create authorizer
+                var authorizer = new OAuthAuthorizer(consumerKey, consumerSecret);
+            
+                // get request token
+                List<KeyValuePair<string, string>> args = new List<KeyValuePair<string, string>>();
+                args.Add(new KeyValuePair<string, string>("oauth_callback", "oob"));
+              
+                var tokenResponse = await authorizer.GetRequestToken("https://etws.etrade.com/oauth/request_token",args);
+                var requestToken = tokenResponse.Token;
+               
+
+                //   var pinRequestUrl = authorizer.BuildAuthorizeUrl("https://us.etrade.com/e/t/etws/authorize", requestToken);
+                string pinRequestUrl = "https://us.etrade.com/e/t/etws/authorize" + "?key=" + consumerKey + "&token=" + requestToken.Key;
+                // open browser and get PIN Code
+                Process.Start(pinRequestUrl);
+
+                // enter pin
+                Console.WriteLine("ENTER PIN");
+                var pinCode = Console.ReadLine();
+
+                // get access token
+              
+                var accessTokenResponse = await authorizer.GetAccessToken("https://etws.etrade.com/oauth/access_token", requestToken, pinCode);
+
+                // save access token.
+                var accessToken = accessTokenResponse.Token;
+                Console.WriteLine("Access Granted: ");
+                Console.WriteLine("  Access Key:" + accessToken.Key);
+                Console.WriteLine("  Access Secret:" + accessToken.Secret);
+                Console.WriteLine("===============================================");
+
+                return accessToken;
+            }
+            catch (Exception e)
+            {
+                Console.WriteLine("Exception " + e.ToString());
+            }
+
+            return null;
+        }
+
+        public async Task<string> GetQuote()
+        {
+            try
+            {
+
+
+                var client = OAuthUtility.CreateOAuthClient(consumerKey, consumerSecret, accessToken);
+
+                var json = await client.GetStringAsync("https://etwssandbox.etrade.com/market/sandbox/rest/quote/GOOG,MSFT.json?detailFlag=FUNDAMENTAL");
+
+                return json;
+            }
+            catch (Exception e )
+            {
+                Console.WriteLine("Exception in GetQuote: " + e.ToString());
+            }
+
+            return null;
+        }
+
+       
+    }
+}

--- a/AsyncOAuth.ConsoleApp/Program.cs
+++ b/AsyncOAuth.ConsoleApp/Program.cs
@@ -12,26 +12,51 @@ namespace AsyncOAuth.ConsoleApp
     class Program
     {
         // set your token
-        const string consumerKey = "";
-        const string consumerSecret = "";
+        /*Dear Graham Briggs,
+                   This message is regarding the E*TRADE API.
+                   Your key and secret for the sandbox environment are as follows:
+                       oauth_consumer_key: b3de705c7e73dba19ed2cd406f24ea00 
+                       consumer_secret: 41486fa59ab14b564d294b8b18e3fcb7	*/
+
+        const string consumerKey = "b3de705c7e73dba19ed2cd406f24ea00";
+        const string consumerSecret = "41486fa59ab14b564d294b8b18e3fcb7";
 
         static async Task Run()
         {
             // initialize computehash function
             OAuthUtility.ComputeHash = (key, buffer) => { using (var hmac = new HMACSHA1(key)) { return hmac.ComputeHash(buffer); } };
 
-            // sample, twitter access flow
-            var accessToken = await TwitterClient.AuthorizeSample(consumerKey, consumerSecret);
+            // sample, ETrade access flow
+            Console.WriteLine("ASyncOauth ETrade Sample: ");
+            System.Threading.Thread.Sleep(1000);
 
-            var client = new TwitterClient(consumerKey, consumerSecret, accessToken);
+            Console.WriteLine("Getting access token");
+            var accessToken = await ETradeClient.AuthorizeSample(consumerKey, consumerSecret);
 
-            var tl = await client.GetTimeline(10, 1);
-            Console.WriteLine(tl);
+            if ( accessToken == null )
+            {
+                Console.WriteLine("Error getting access token");
+                return;
+            }
+
+            //  create the client with the access token and consumer key
+            var client = new ETradeClient(consumerKey, consumerSecret, accessToken);
+
+            //  Get Quote:
+            Console.WriteLine("Getting Quotes from sandbox server: ");
+
+            var quoteResponse = await client.GetQuote();
+
+            Console.WriteLine(quoteResponse);
         }
 
         static void Main(string[] args)
         {
             Run().Wait();
+
+            //  Exit
+            Console.WriteLine("Press any key to exit.");
+            Console.ReadKey();
         }
     }
 }

--- a/AsyncOAuth/OAuthUtility.cs
+++ b/AsyncOAuth/OAuthUtility.cs
@@ -76,9 +76,26 @@ namespace AsyncOAuth
             if (token != null) parameters.Add(new KeyValuePair<string, string>("oauth_token", token.Key));
             if (optionalParameters == null) optionalParameters = Enumerable.Empty<KeyValuePair<string, string>>();
 
+            //  generate the signature
             var signature = GenerateSignature(consumerSecret, new Uri(url), method, token, parameters.Concat(optionalParameters));
 
+            //  add the signature to the parameters
             parameters.Add(new KeyValuePair<string, string>("oauth_signature", signature));
+
+            //  TODO - this is a change made to get library to work with ETrade OAuth login
+            //  the token must be URL encoded, but if you URL encode token prior to generate signature, signature is incorrect
+            //  this is brute force solution that worked for me, but there is probably a better way to handle this
+            try
+            {
+                var findToken = parameters.First(x => x.Key == "oauth_token");
+
+                parameters.Remove(findToken);
+                parameters.Add(new KeyValuePair<string, string>(findToken.Key, findToken.Value.UrlEncode()));
+            }
+            catch
+            {
+                //  oauth_token is not in the header, continue
+            }
 
             return parameters;
         }


### PR DESCRIPTION
I had to modify the library to get it to work with ETrade OAuth login

Not sure if this breaks anything else. Don't know enough about the subject to say for sure?

Please review and comment if this is a universally good change, if this change could be accomplished in a more elegant manner, or is it just a hack that happens to work in my case?

Thank you

GB
