### PR TITLE
Fixed signature calculation for PUT requests with FormUrlEncodedContent

### DIFF
--- a/AsyncOAuth/OAuthMessageHandler.cs
+++ b/AsyncOAuth/OAuthMessageHandler.cs
@@ -33,7 +33,7 @@ namespace AsyncOAuth
         protected async override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, System.Threading.CancellationToken cancellationToken)
         {
             var sendParameter = parameters;
-            if (request.Method == HttpMethod.Post)
+            if (request.Method == HttpMethod.Post || request.Method == HttpMethod.Put)
             {
                 // form url encoded content
                 if (request.Content is FormUrlEncodedContent)


### PR DESCRIPTION
When sending a PUT request with`FormUrlEncodedContent` the OAuth signature was not generated correctly. I had to add this minor fix to get this working. 
I am not quite sure if this breaks anything, since I am not that familar with OAuth.
